### PR TITLE
better counts

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,8 @@ mut_types = list(map("".join,permutations("AGCT",2)))
 rule all:
     input:       
         expand(
-            "results_{mat}/data/counts_by_mut_type_{seg}.png",
+            #"results_{mat}/results/counts_by_mut_type_{seg}.png",
+            "results_{mat}/results/tree_sizes_{seg}.csv",
             mat=config["files_to_grab"]["mat"],
             seg=segs
         )
@@ -101,7 +102,7 @@ rule makes_coding_dicts:
 
 bad_site_files = expand('bad_sites_{seg}.csv', seg=segs)
 secondary_structs_files = expand('secondary_struct_{seg}.csv', seg=segs)
-rates_tables_files = expand('rates_bad_sites_{seg}.csv', seg=segs)
+rates_tables_files = expand('rates_{seg}.csv', seg=segs)
 rule make_placeholder_files:
     output: 
         bad_sites_paths=["results_{mat}/data/"+file for file in bad_site_files],
@@ -111,13 +112,11 @@ rule make_placeholder_files:
         "scripts/make_placeholder_files.py"
 
 
-
-nuc_count_files = expand("nt_mut_id_counts_{seg}.csv", seg=segs)
+all_counts_files = expand("all_counts_{seg}.csv", seg=segs)
+all_pcps_files = expand("all_pcps_{seg}.csv", seg=segs)
 nuc_conservation_files = expand("nt_conservation_{seg}.csv", seg=segs)
-codon_count_files = expand("codon_mut_id_counts_{seg}.csv", seg=segs)
 codon_conservation_files = expand("codon_conservation_{seg}.csv", seg=segs)
-possible_muts_files = expand("possible_muts_{seg}.csv", seg=segs)
-all_count_files = expand("all_counts_{seg}.csv", seg=segs)
+tree_size_files = expand("tree_sizes_{seg}.csv", seg=segs)
 rule make_count_dfs:
     input:
         rerooted_tree_paths=["results_{mat}/data/rerooted_" + file for file in pbs],
@@ -128,12 +127,11 @@ rule make_count_dfs:
         secondary_structs=["results_{mat}/data/"+file for file in secondary_structs_files], 
         rates_tables=["results_{mat}/data/"+file for file in rates_tables_files],
     output:
-        nuc_count_paths=["results_{mat}/data/"+file for file in nuc_count_files],
-        nuc_conservation_paths=["results_{mat}/data/"+file for file in nuc_conservation_files],
-        codon_count_paths=["results_{mat}/data/"+file for file in codon_count_files],
-        codon_conservation_paths=["results_{mat}/data/"+file for file in codon_conservation_files],
-        possible_muts_paths=["results_{mat}/data/"+file for file in possible_muts_files],
-        all_count_paths=["results_{mat}/data/"+file for file in all_count_files]
+        all_counts_paths=["results_{mat}/results/"+file for file in all_counts_files],
+        all_pcps_paths=["results_{mat}/results/"+file for file in all_pcps_files],
+        nuc_conservation_paths=["results_{mat}/results/"+file for file in nuc_conservation_files],
+        codon_conservation_paths=["results_{mat}/results/"+file for file in codon_conservation_files],
+        tree_size_paths=["results_{mat}/results/"+file for file in tree_size_files]
     script:
         "scripts/make_count_dfs.py"
 
@@ -143,12 +141,11 @@ mut_type_dirs = expand("scatter_plots_{seg}/", seg=segs)
 mut_type_files = expand("scatter_plots_{seg}/{mt}.png", seg=segs, mt=mut_types)
 rule make_basic_plots:
     input:
-        all_count_paths=["results_{mat}/data/"+file for file in all_count_files]
+        all_counts_paths=["results_{mat}/results/"+file for file in all_counts_files]
     output:
-        boxplot_paths = ["results_{mat}/data/"+file for file in boxplot_files],
-        mut_type_paths = ["results_{mat}/data/"+file for file in mut_type_files]
+        boxplot_paths = ["results_{mat}/results/"+file for file in boxplot_files],
+        mut_type_paths = ["results_{mat}/results/"+file for file in mut_type_files]
     params:
-        mut_type_dirs = ["results_{mat}/data/"+file for file in mut_type_dirs]
+        mut_type_dirs = ["results_{mat}/results/"+file for file in mut_type_dirs]
     script:
         "scripts/basic_plots.py"
-

--- a/config.yaml
+++ b/config.yaml
@@ -9,14 +9,14 @@ files_to_grab:
   pb: ".latest.pb.gz"  
   
   segments:
-    PB2: NC_007373.1
-    PB1: NC_007372.1
-    PA: NC_007371.1
+    #PB2: NC_007373.1
+    #PB1: NC_007372.1
+    #PA: NC_007371.1
     HA: NC_007366.1
-    NP: NC_007369.1
-    NA: NC_007368.1
-    MP: NC_007367.1
-    NS: NC_007370.1  
+    #NP: NC_007369.1
+    #NA: NC_007368.1
+    #MP: NC_007367.1
+    #NS: NC_007370.1  
 
 #  mat: https://hgdownload.gi.ucsc.edu/hubs/GCF/000/865/085/GCF_000865085.1/UShER_NC_007366.1/
 

--- a/config.yaml
+++ b/config.yaml
@@ -9,14 +9,14 @@ files_to_grab:
   pb: ".latest.pb.gz"  
   
   segments:
-    #PB2: NC_007373.1
-    #PB1: NC_007372.1
-    #PA: NC_007371.1
+    PB2: NC_007373.1
+    PB1: NC_007372.1
+    PA: NC_007371.1
     HA: NC_007366.1
-    #NP: NC_007369.1
-    #NA: NC_007368.1
-    #MP: NC_007367.1
-    #NS: NC_007370.1  
+    NP: NC_007369.1
+    NA: NC_007368.1
+    MP: NC_007367.1
+    NS: NC_007370.1  
 
 #  mat: https://hgdownload.gi.ucsc.edu/hubs/GCF/000/865/085/GCF_000865085.1/UShER_NC_007366.1/
 

--- a/scripts/ExpectedCalc.py
+++ b/scripts/ExpectedCalc.py
@@ -386,8 +386,9 @@ class PossibleMutations:
                 is a mutation resulting in 'G' at site 25 (which is at index 24 of
                 sequence).
         """
-        cols_to_keep = ["site", "wt_nt", "mut_nt", "is_synonymous", "ID"]
-        ret = self.reference_mutations_df[cols_to_keep].copy()
+        # cols_to_keep = ["site", "wt_nt", "mut_nt", "is_synonymous", "ID"]
+        # ret = self.reference_mutations_df[cols_to_keep].copy()
+        ret = self.reference_mutations_df.copy()
         if len(founder_muts) == 0:
             return ret, self.ref_seq
 

--- a/scripts/basic_plots.py
+++ b/scripts/basic_plots.py
@@ -29,7 +29,7 @@ def make_plots(all_counts_path, boxplot_path, mut_type_dir):
 
 def plot_counts_by_mut_type(counts_df, outpath):
     plt.figure(figsize=[8, 3])
-    sns.boxplot(x="mut_type", y="counts", data=counts_df, whis=(5, 95))
+    sns.boxplot(x="mut_type", y="actual_count", data=counts_df, whis=(5, 95))
     plt.yscale("log")
     sns.despine()
     plt.savefig(outpath)
@@ -40,7 +40,7 @@ def plot_counts_by_mut_type(counts_df, outpath):
 def plot_counts_for_mut_type(counts_df, mut_type, outpath):
     data = counts_df.query("mut_type==@mut_type")
     plt.figure(figsize=[12, 3])
-    sns.scatterplot(x="site", y="counts", data=data, alpha=0.5)
+    sns.scatterplot(x="site", y="actual_count", data=data, alpha=0.5)
     plt.title(f"{mut_type}, N={len(data)}")
     sns.despine()
     plt.savefig(outpath)

--- a/scripts/basic_plots.py
+++ b/scripts/basic_plots.py
@@ -7,14 +7,10 @@ import os
 sns.set_theme(font_scale=1.0, style="ticks", palette="colorblind")
 
 
-all_count_paths = snakemake.input.all_count_paths
-boxplot_paths = snakemake.output.boxplot_paths
-mut_type_dirs = snakemake.params.mut_type_dirs
-
-
 def make_plots(all_counts_path, boxplot_path, mut_type_dir):
     syn_counts_df = pd.read_csv(all_counts_path)
-    syn_counts_df.query("is_synonymous == True", inplace=True)
+    syn_counts_df.query("is_synonymous == True and actual_count>0", inplace=True)
+    syn_counts_df["mut_type"] = syn_counts_df.wt_nt + syn_counts_df.mut_nt
     syn_counts_df.sort_values("mut_type", inplace=True)
 
     plot_counts_by_mut_type(syn_counts_df, boxplot_path)
@@ -48,4 +44,11 @@ def plot_counts_for_mut_type(counts_df, mut_type, outpath):
     return None
 
 
-any(make_plots(*p) for p in zip(all_count_paths, boxplot_paths, mut_type_dirs))
+if __nbame__ == "__main__":
+    # In main hook, so rest of file can be imported.
+
+    all_counts_paths = snakemake.input.all_counts_paths
+    boxplot_paths = snakemake.output.boxplot_paths
+    mut_type_dirs = snakemake.params.mut_type_dirs
+
+    any(make_plots(*p) for p in zip(all_counts_paths, boxplot_paths, mut_type_dirs))

--- a/scripts/make_count_dfs.py
+++ b/scripts/make_count_dfs.py
@@ -1,37 +1,246 @@
-# import pandas as pd
 from pandas import DataFrame as DF
 from collections import defaultdict, Counter
 import bte
 from ExpectedCalc import PossibleMutations, apply_muts
+from time import time
+from multiprocessing import Pool
+from math import ceil
 
 # from MATWrapper import apply_muts
 
 
-rerooted_tree_paths = snakemake.input.rerooted_tree_paths
-coding_site_paths = snakemake.input.coding_site_paths
-fasta_paths = snakemake.input.fasta_paths
-gtf_paths = snakemake.input.gtf_paths
-bad_sites_paths = snakemake.input.bad_sites_paths
-secondary_structs = snakemake.input.secondary_structs
-rates_tables = snakemake.input.rates_tables
-nuc_count_paths = snakemake.output.nuc_count_paths
-nuc_conservation_paths = snakemake.output.nuc_conservation_paths
-codon_count_paths = snakemake.output.codon_count_paths
-codon_conservation_paths = snakemake.output.codon_conservation_paths
-possible_muts_paths = snakemake.output.possible_muts_paths
-all_count_paths = snakemake.output.all_count_paths
+class CountsHelper:
+    """...handles calculating and writing out mutation counts and conservation per sites..."""
 
+    def __init__(
+        self,
+        tree_path,
+        coding_site_path,
+        fasta_path,
+        gtf_path,
+        bad_sites,
+        secondary,
+        rates,
+    ):
+        self.poss_muts = PossibleMutations(
+            fasta_path, coding_site_path, bad_sites, secondary, rates, False
+        )
+        self.ref_seq = self.poss_muts.ref_seq
 
-def get_3mer_seq_context(nt_site, seq):
-    return seq[nt_site - 2 : nt_site + 1]
+        ref_df = self.poss_muts.possible_mutations_df()
+        self.key_names = (*ref_df.columns, "parent_motif")
+        ref_df["gene_codon_site_id"] = ref_df["gene"] + "-" + ref_df["codon_sites"]
+        ref_df["seq_context"] = ref_df.site.apply(self.ref_motif)
+        self.ref_df = ref_df
 
+        self.tree = bte.MATree(tree_path)
+        self.translations = defaultdict(list, self.tree.translate(gtf_path, fasta_path))
+        self.nodes = self.tree.depth_first_expansion()
+        self.int_nodes = [n for n in self.nodes if not n.is_leaf()]
+        self.n_nodes = len(self.nodes)
+        self.n_int_nodes = len(self.int_nodes)
 
-def fails_filters(node, ref_seq, nt_muts, codon_muts):
-    fail = node.parent is None
-    fail |= len(nt_muts) > 4
-    fail |= sum(ref_seq[int(mut[1:-1]) - 1] == mut[-1] for mut in nt_muts) > 1
-    fail |= len({(mut.gene, mut.aa_index) for mut in codon_muts}) < len(codon_muts)
-    return fail
+    def ref_motif(self, s):
+        return self.ref_seq[s - 2 : s + 1]
+
+    def fails_filters(self, nt_muts, codon_muts):
+        fail = len(nt_muts) > 4
+        fail |= len(nt_muts) == 0
+        fail |= sum(self.ref_seq[int(mut[1:-1]) - 1] == mut[-1] for mut in nt_muts) > 1
+        fail |= len({(mut.gene, mut.aa_index) for mut in codon_muts}) < len(codon_muts)
+        return fail
+
+    def count_mutations_from_parent(self, parent):
+        parent_node_haplotype = self.tree.get_haplotype(parent.id)
+        p_muts = {int(mut[1:-1]): mut[-1] for mut in parent_node_haplotype}
+
+        # If speed is an issue, we can rewrite the possible_muts_from_founder_muts
+        # method to avoid dataframes.
+        counts_df, parent_seq = self.poss_muts.possible_muts_from_founder_muts(p_muts)
+        parent_motif = lambda s: parent_seq[s - 2 : s + 1]
+        counts_df["parent_motif"] = counts_df.site.apply(parent_motif)
+        counts_df["actual_count"] = 0
+        counts_df["branch_length"] = 0
+        pcps = (parent.id, parent_seq, [])
+
+        n_filtered = 0
+        for node in parent.children:
+            nt_muts = node.mutations
+            codon_muts = self.translations[node.id]
+            if self.fails_filters(nt_muts, codon_muts):
+                continue
+
+            n_filtered += 1
+            pcps[2].append((node.id, nt_muts))
+            counts_df["branch_length"] += len(nt_muts)
+            to_increment = counts_df.query("nuc.isin(@node.mutations)").index
+            counts_df.loc[to_increment, "actual_count"] += 1
+
+        if n_filtered != 0:
+            records = counts_df.to_records(index=False).tolist()
+            counts_dict = Counter({x[:-2]: x[-2] for x in records})
+            branches_dict = Counter({x[:-2]: x[-1] for x in records})
+        else:
+            counts_dict, branches_dict = Counter(), Counter()
+
+        return n_filtered, counts_dict, branches_dict, pcps
+
+    def count_sites_on_node(self, node):
+        """...return Counter where keys are nucleutide sites or codon sites
+        ...with a mutation at this node and those sites...
+        """
+        node_haplotype = self.tree.get_haplotype(node.id)
+        nt_site_count = Counter([mut[1:-1] for mut in node_haplotype])
+        view = self.ref_df.query("nuc.isin(@node_haplotype)")
+        codon_site_count = Counter(set(view.gene_codon_site_id))
+        return nt_site_count, codon_site_count
+
+    def mut_counters_to_df(self, actual_counts, branch_lengths):
+        """
+        ...turn a counter with keys as tuples of self.key_names and values for column name
+        ....
+        ...into a df with columns key names and column name...
+        """
+        zipped = zip(actual_counts.items(), branch_lengths.values())
+        data = [(*k, v, w) for (k, v), w in zipped]
+        columns = [*self.key_names, "actual_count", "branch_length"]
+        the_df = DF(data, columns=columns)
+        return the_df
+
+    def site_counter_to_df(self, counter, n_filtered):
+        """
+        ...turn a counter with keys as site s and values for column name
+        ....
+        ...into a df with columns key names and column name...
+        """
+        the_df = DF.from_dict(counter, orient="index")
+        the_df.reset_index(inplace=True)
+        the_df.rename(columns={"index": "site", 0: "mut_count"}, inplace=True)
+        the_df["frac_mut"] = the_df.mut_count / n_filtered
+        the_df["frac_cons"] = 1 - the_df.frac_mut
+        the_df.sort_values("mut_count", ascending=False, inplace=True)
+        return the_df
+
+    def compute_conservation_on_tree(self):
+        """
+        ...
+        """
+        # Use counters rather than a dataframe, since summing together many.
+        n_filtered, nt_site_counter, codon_site_counter = 0, Counter(), Counter()
+        t0 = -time()
+        for i, node in enumerate(self.int_nodes, 1):
+            nt_muts = node.mutations
+            codon_muts = self.translations[node.id]
+            if self.fails_filters(nt_muts, codon_muts):
+                continue
+            n_filtered += 1
+
+            nt_site_count, codon_site_count = self.count_sites_on_node(node)
+            nt_site_counter.update(nt_site_count)
+            codon_site_counter.update(codon_site_count)
+            if i % 1000 == 0:
+                print(f"{i} nodes processed in {t0+time():0.1f} seconds")
+
+        nt_site_df = self.site_counter_to_df(nt_site_counter, n_filtered)
+        codon_site_df = self.site_counter_to_df(codon_site_counter, n_filtered)
+        return n_filtered, nt_site_df, codon_site_df
+
+    def count_mutations_on_tree(self):
+        """
+        # Cycle over nodes and record codon mutation counts
+        ...returns int, Counter, Counter
+        """
+        # Use counters rather than a dataframe, since summing together many.
+        n_filtered, all_actual_counts, all_branch_lengths = 0, Counter(), Counter()
+        all_pcps = []
+        t0 = -time()
+        for i, node in enumerate(self.int_nodes, 1):
+            count, actual_counts, branch_lens, pcps = self.count_mutations_from_parent(
+                node
+            )
+            n_filtered += count
+            all_actual_counts.update(actual_counts)
+            all_branch_lengths.update(branch_lens)
+            if count != 0:
+                all_pcps.append(pcps)
+
+            if i % 1000 == 0:
+                print(f"{i} nodes processed in {t0+time():0.1f} seconds")
+        all_counts_df = self.mut_counters_to_df(all_actual_counts, all_branch_lengths)
+        all_pcps_df = self.pcp_list_to_df(all_pcps)
+        return n_filtered, all_counts_df, all_pcps_df
+
+    def parallel_count_mutations_on_tree(self, processes=8, batch_size=1000):
+        """
+        ...
+        """
+        raise NotImplementedError(
+            "Can't multiprocess with bte tree, need to do extra book keeping."
+        )
+        n_filtered, all_actual_counts, all_branch_lengths = 0, Counter(), Counter()
+        batch_count = ceil(self.n_int_nodes / batch_size)
+        t0 = -time()
+        with Pool(processes=processes) as pool:
+            for b in range(batch_count):
+                if b == batch_count - 1:
+                    nodes = self.int_nodes[b * batch_size : (b + 1) * batch_size]
+                else:
+                    nodes = self.int_nodes[b * batch_size :]
+                batch_result = pool.map(self.count_mutations_from_parent, nodes)
+                for count, actual_counts, branch_lens in batch_result:
+                    n_filtered += count
+                    all_actual_counts.update(actual_counts)
+                    all_branch_lengths.update(branch_lens)
+
+            print(
+                f"{b} batches of {batch_size} nodes processed in {t0+time():0.1f} seconds"
+            )
+        all_counts_df = self.mut_counters_to_df(all_actual_counts, all_branch_lengths)
+        return n_filtered, all_counts_df
+
+    def pcp_list_to_df(self, pcps):
+        mut_dict = lambda muts: {int(mut[1:-1]): mut[-1] for mut in muts}
+        child_seq = lambda seq, muts: apply_muts(seq, mut_dict(muts))
+        cols = ["parent_name", "child_name", "parent", "child", "branch_length"]
+        rows = (
+            (p_id, c_id, p_seq, child_seq(p_seq, c_muts), len(c_muts))
+            for (p_id, p_seq, child_entries) in pcps
+            for c_id, c_muts in child_entries
+        )
+        the_df = DF(rows, columns=cols)
+        return the_df
+
+    def make_and_write_all_counts(
+        self,
+        all_counts_path,
+        all_pcps_path,
+        nuc_conserv_path,
+        codon_conserv_path,
+        tree_size_path,
+    ):
+        print(f"Number of nodes in tree: {self.n_nodes}")
+        print(f"Number of internal nodes in tree: {self.n_int_nodes}")
+
+        print(f"Counting mutations on tree...")
+        n_filtered, all_counts_df, all_pcps_df = self.count_mutations_on_tree()
+        print(f"Number of nodes passing filter: {n_filtered}")
+
+        print(f"Calculating site conservation on tree...")
+        n_int_filtered, nt_site_df, codon_site_df = self.compute_conservation_on_tree()
+        print(f"Number of internal nodes passing filter: {n_filtered}")
+
+        all_counts_df.to_csv(all_counts_path)
+        all_pcps_df.to_csv(all_pcps_path)
+        nt_site_df.to_csv(nuc_conserv_path)
+        codon_site_df.to_csv(codon_conserv_path)
+
+        with open(tree_size_path, "w") as the_file:
+            header = "nodes,internal_nodes,filtered_nodes,filtered_internal_nodes\n"
+            row = f"{self.n_nodes},{self.n_int_nodes},{n_filtered},{n_int_filtered}\n"
+            the_file.write(header)
+            the_file.write(row)
+
+        return None
 
 
 def write_counts(
@@ -42,136 +251,50 @@ def write_counts(
     bad_sites,
     secondary,
     rates,
-    nuc_count_path,
+    all_counts_path,
+    all_pcps_path,
     nuc_conserv_path,
-    codon_count_path,
     codon_conserv_path,
-    possible_muts_path,
-    all_count_path,
+    tree_size_path,
 ):
-    possible_muts = PossibleMutations(
-        fasta_path, coding_site_path, bad_sites, secondary, rates, False
+    p1 = tree_path, coding_site_path, fasta_path, gtf_path, bad_sites, secondary, rates
+    p2 = (
+        all_counts_path,
+        all_pcps_path,
+        nuc_conserv_path,
+        codon_conserv_path,
+        tree_size_path,
     )
-    ref_seq = possible_muts.ref_seq
-    ref_df = possible_muts.possible_mutations_df()
-    ref_df.rename(columns={"codon_sites": "codon_site"}, inplace=True)
-    ref_df.drop(columns=["ID"], inplace=True)
-    ref_df["gene_codon_site_id"] = ref_df["gene"] + "-" + ref_df["codon_site"]
-    ref_df["seq_context"] = ref_df.site.apply(get_3mer_seq_context, args=(ref_seq,))
-    ref_df.to_csv(possible_muts_path)
-
-    tree = bte.MATree(tree_path)
-    translations = tree.translate(gtf_path, fasta_path)
-
-    # Cycle over nodes and record codon mutation counts
-    nodes = tree.depth_first_expansion()
-    print("Number of nodes in tree:", len(nodes))
-    nt_mut_counts = defaultdict(int)
-    codon_mut_counts = defaultdict(int)
-    conserv_nt_ctr = Counter()
-    conserv_codon_ctr = Counter()
-    n_nodes_passing_filters = 0
-    n_internal_nodes_analyzed = 0
-    for i, node in enumerate(nodes):
-        # Get lists of nt-level and codon-level mutations
-        nt_muts = node.mutations
-        codon_muts = translations[node.id] if node.id in translations else []
-        if fails_filters(node, ref_seq, nt_muts, codon_muts):
-            continue
-
-        n_nodes_passing_filters += 1
-
-        # Reconstruct the parent node's genome for use in getting each mutation's
-        # sequence context
-        node_haplotype = tree.get_haplotype(node.id)
-        parent_node_haplotype = tree.get_haplotype(node.parent.id)
-        parent_muts = {int(mut[1:-1]): mut[-1] for mut in parent_node_haplotype}
-        parent_node_seq = apply_muts(ref_seq, parent_muts)
-
-        # Record counts of nt-level mutations
-        for nt_mut in nt_muts:
-            seq_context = get_3mer_seq_context(int(nt_mut[1:-1]), parent_node_seq)
-            ref_seq_context = get_3mer_seq_context(int(nt_mut[1:-1]), ref_seq)
-            nt_mut_id = f"{nt_mut}-{seq_context}-{ref_seq_context}"
-            nt_mut_counts[nt_mut_id] += 1
-
-        # Record counts of codon-level mutations
-        for codon_mut in codon_muts:
-            nt_mut = codon_mut.nuc
-            seq_context = get_3mer_seq_context(int(nt_mut[1:-1]), parent_node_seq)
-            ref_seq_context = get_3mer_seq_context(int(nt_mut[1:-1]), ref_seq)
-            codon_mut_id = f"{codon_mut.gene}-{codon_mut.aa_index}-{codon_mut.original_codon}-{codon_mut.alternative_codon}-{seq_context}-{ref_seq_context}"
-            codon_mut_counts[codon_mut_id] += 1
-
-        # Record rolling counts of all nt-level and codon-level mutations in a node
-        # relative to the reference sequence in order to determine the level of
-        # conservation at each site. Only do this for internal nodes.
-        if not node.is_leaf():
-            n_internal_nodes_analyzed += 1
-            node_counts = Counter([mut[1:-1] for mut in node_haplotype])
-            conserv_nt_ctr += node_counts
-            q = "nuc.isin(@node_haplotype)"
-            node_counts = Counter(set(ref_df.query(q).gene_codon_site_id))
-            conserv_codon_ctr += node_counts
-
-        if i % 10000 == 0:
-            print(i)
-
-    print("Number of nodes that passed filters:", n_nodes_passing_filters)
-    print("Number of internal nodes analyzed:", n_internal_nodes_analyzed)
-
-    # Store mutation counts in dataframes and write out.
-    cols = ["nt_mut_id", "counts"]
-    nt_mut_counts_df = DF.from_records(list(nt_mut_counts.items()), columns=cols)
-    new_cols = ["nt_mut", "mut_seq_context", "ref_seq_context"]
-    new_vals = nt_mut_counts_df["nt_mut_id"].str.extract("(\w+)-(\w+)-(\w+)")
-    nt_mut_counts_df[new_cols] = new_vals
-    nt_mut_counts_df.drop(columns=["nt_mut_id"], inplace=True)
-    nt_mut_counts_df.to_csv(nuc_count_path, index=False)
-
-    cols = ["codon_mut_id", "counts"]
-    codon_mut_counts_df = DF.from_records(list(codon_mut_counts.items()), columns=cols)
-    new_cols = ["gene", "codon_site", "wt_codon", "mut_codon", "mut_seq_context"]
-    new_cols.append("ref_seq_context")
-    id_format = "(\w+)-(\d+)-(\w+)-(\w+)-(\w+)-(\w+)"
-    new_vals = codon_mut_counts_df["codon_mut_id"].str.extract(id_format)
-    codon_mut_counts_df[new_cols] = new_vals
-    codon_mut_counts_df.drop(columns=["codon_mut_id"], inplace=True)
-    codon_mut_counts_df.to_csv(codon_count_path, index=False)
-
-    join_cols = ["codon_site", "wt_codon", "mut_codon", "gene"]
-    all_counts_df = ref_df.merge(codon_mut_counts_df, on=join_cols, how="left")
-    all_counts_df["mut_type"] = all_counts_df.wt_nt + all_counts_df.mut_nt
-    all_counts_df["codon_site"] = all_counts_df.codon_site.astype(int)
-    all_counts_df["counts"] = all_counts_df.counts.fillna(0).astype(int)
-    all_counts_df.to_csv(all_count_path, index=False)
-
-    pairs = (conserv_nt_ctr, nuc_conserv_path), (conserv_codon_ctr, codon_conserv_path)
-    for ctr, path in pairs:
-        the_df = DF.from_dict(ctr, orient="index")
-        the_df.reset_index(inplace=True)
-        the_df.rename(columns={"index": "site", 0: "count"}, inplace=True)
-        the_df["frac_mut"] = the_df["count"] / n_internal_nodes_analyzed
-        the_df["frac_cons"] = 1 - the_df["frac_mut"]
-        the_df.sort_values("count", ascending=False, inplace=True)
-        the_df.to_csv(path, index=False)
-
+    CountsHelper(*p1).make_and_write_all_counts(*p2)
     return None
 
 
-params = zip(
-    rerooted_tree_paths,
-    coding_site_paths,
-    fasta_paths,
-    gtf_paths,
-    bad_sites_paths,
-    secondary_structs,
-    rates_tables,
-    nuc_count_paths,
-    nuc_conservation_paths,
-    codon_count_paths,
-    codon_conservation_paths,
-    possible_muts_paths,
-    all_count_paths,
-)
-any(write_counts(*p) for p in params)
+if __name__ == "__main__":
+    rerooted_tree_paths = snakemake.input.rerooted_tree_paths
+    coding_site_paths = snakemake.input.coding_site_paths
+    fasta_paths = snakemake.input.fasta_paths
+    gtf_paths = snakemake.input.gtf_paths
+    bad_sites_paths = snakemake.input.bad_sites_paths
+    secondary_structs = snakemake.input.secondary_structs
+    rates_tables = snakemake.input.rates_tables
+    all_counts_paths = snakemake.output.all_counts_paths
+    all_pcps_paths = snakemake.output.all_pcps_paths
+    nuc_conservation_paths = snakemake.output.nuc_conservation_paths
+    codon_conservation_paths = snakemake.output.codon_conservation_paths
+    tree_size_paths = snakemake.output.tree_size_paths
+
+    params = zip(
+        rerooted_tree_paths,
+        coding_site_paths,
+        fasta_paths,
+        gtf_paths,
+        bad_sites_paths,
+        secondary_structs,
+        rates_tables,
+        all_counts_paths,
+        all_pcps_paths,
+        nuc_conservation_paths,
+        codon_conservation_paths,
+        tree_size_paths,
+    )
+    any(write_counts(*p) for p in params)

--- a/scripts/make_count_dfs.py
+++ b/scripts/make_count_dfs.py
@@ -10,7 +10,23 @@ from math import ceil
 
 
 class CountsHelper:
-    """...handles calculating and writing out mutation counts and conservation per sites..."""
+    """
+    Helper class for calculating and writing per site mutation counts and conservation.
+
+    Attributes:
+        int_nodes (list): The internal nodes of the tree.
+        key_names (tuple): Column names that also serve as keys for Counters.
+        n_int_nodes (int): The number of internal nodes of the tree.
+        n_nodes (int): The number of nodes in the tree.
+        nodes (list): The nodes of the tree.
+        poss_muts (PossibleMutations): Possible Mutations instance for the data.
+        ref_df (pd.DataFrame) = DataFrame of possible mutations from the reference
+            sequence, along with additonal information.
+        ref_seq (str): The reference sequence.
+        translations (defaultdict): A default dictionary mapping a node id to the codon
+            mutations at the node.
+        tree (bte.MATree): Instance of the tree.
+    """
 
     def __init__(
         self,
@@ -22,6 +38,22 @@ class CountsHelper:
         secondary,
         rates,
     ):
+        """
+        Parameters:
+            tree_path (str): The tree.
+            coding_site_path (str): The coding sites dataframe (nucleotide site to codon
+                and gene).
+            fasta_path (str): The fasta for the reference sequence.
+            gtf_path (str):
+            bad_sites (str): The file listing bad sites for initializing self.poss_muts.
+                Currently this is a dummy file, no known bad sites.
+            secondary (str): The file listing secondary structure predictions for
+                initializing self.poss_muts. Currently this is a dummy file, no known
+                secondary structure.
+            rates (str): The file of rates for different mutation types for initializing
+                self.poss_muts. Currently this is a dummy file, no master rates table.
+        """
+
         self.poss_muts = PossibleMutations(
             fasta_path, coding_site_path, bad_sites, secondary, rates, False
         )
@@ -41,9 +73,20 @@ class CountsHelper:
         self.n_int_nodes = len(self.int_nodes)
 
     def ref_motif(self, s):
+        """Return the 3-mer motif centered at the site. Site indices begin at one."""
         return self.ref_seq[s - 2 : s + 1]
 
     def fails_filters(self, nt_muts, codon_muts):
+        """
+        Returns true if the mutations at a node fail the filter. The filter requires
+        that there are between one and four mutations; there is at most one reversion to
+        the reference sequence; and no two mutations target the same codon.
+
+        Parameters:
+            nt_mut (list): List of nucleotide mutations, string entries like "A1234G".
+            codon_muts (list): List of codon mutations, entries are bte.AAChange
+                objects.
+        """
         fail = len(nt_muts) > 4
         fail |= len(nt_muts) == 0
         fail |= sum(self.ref_seq[int(mut[1:-1]) - 1] == mut[-1] for mut in nt_muts) > 1
@@ -51,6 +94,16 @@ class CountsHelper:
         return fail
 
     def count_mutations_from_parent(self, parent):
+        """
+        Count mutations from the parent node to all of its child nodes. Return four
+        values, which are the number of child nodes that pass the filter;
+        a Counter mapping a tuple of values for self.key_names to the number of times
+        the associating mutation type occured; a Counter mapping a tuple of values for
+        self.key_names to the sum of branch lengths where the mutation type is possible;
+        and a list of parent child pairs, where each entry is a triple with of the
+        parent node id, the parent node sequence, and a list of pairs of child node id
+        and child node sequence.
+        """
         parent_node_haplotype = self.tree.get_haplotype(parent.id)
         p_muts = {int(mut[1:-1]): mut[-1] for mut in parent_node_haplotype}
 
@@ -86,8 +139,11 @@ class CountsHelper:
         return n_filtered, counts_dict, branches_dict, pcps
 
     def count_sites_on_node(self, node):
-        """...return Counter where keys are nucleutide sites or codon sites
-        ...with a mutation at this node and those sites...
+        """
+        Count the sites targetted by mutations on this node. Return two Counters, the
+        first maps a nucleotide site to the number of mutations at that site at this
+        node; the second maps a string identifier of the form "{gene}-{codon_site}" to
+        the number of mutations at that codon site at this node.
         """
         node_haplotype = self.tree.get_haplotype(node.id)
         nt_site_count = Counter([mut[1:-1] for mut in node_haplotype])
@@ -97,9 +153,8 @@ class CountsHelper:
 
     def mut_counters_to_df(self, actual_counts, branch_lengths):
         """
-        ...turn a counter with keys as tuples of self.key_names and values for column name
-        ....
-        ...into a df with columns key names and column name...
+        Return a DataFrame with data from two counters like those returned by
+        self.count_mutations_from_parent.
         """
         zipped = zip(actual_counts.items(), branch_lengths.values())
         data = [(*k, v, w) for (k, v), w in zipped]
@@ -109,9 +164,7 @@ class CountsHelper:
 
     def site_counter_to_df(self, counter, n_filtered):
         """
-        ...turn a counter with keys as site s and values for column name
-        ....
-        ...into a df with columns key names and column name...
+        Return a dataframe with site conservation information from a Counter.
         """
         the_df = DF.from_dict(counter, orient="index")
         the_df.reset_index(inplace=True)
@@ -123,12 +176,17 @@ class CountsHelper:
 
     def compute_conservation_on_tree(self):
         """
-        ...
+        Compute the site conservation along the tree. Return the number of internal
+        nodes passing the filter, a dataframe with nucleotide site conversation, and a
+        dataframe with codon site conservation.
         """
         # Use counters rather than a dataframe, since summing together many.
         n_filtered, nt_site_counter, codon_site_counter = 0, Counter(), Counter()
         t0 = -time()
         for i, node in enumerate(self.int_nodes, 1):
+            if i % 1000 == 0:
+                print(f"processing node {i}; {t0+time():0.1f} seconds")
+
             nt_muts = node.mutations
             codon_muts = self.translations[node.id]
             if self.fails_filters(nt_muts, codon_muts):
@@ -138,8 +196,6 @@ class CountsHelper:
             nt_site_count, codon_site_count = self.count_sites_on_node(node)
             nt_site_counter.update(nt_site_count)
             codon_site_counter.update(codon_site_count)
-            if i % 1000 == 0:
-                print(f"{i} nodes processed in {t0+time():0.1f} seconds")
 
         nt_site_df = self.site_counter_to_df(nt_site_counter, n_filtered)
         codon_site_df = self.site_counter_to_df(codon_site_counter, n_filtered)
@@ -147,14 +203,18 @@ class CountsHelper:
 
     def count_mutations_on_tree(self):
         """
-        # Cycle over nodes and record codon mutation counts
-        ...returns int, Counter, Counter
+        Count the number of mutations along the tree. Return the number of nodes passing
+        the filter, a dataframe of per site nucleotide mutations, and a dataframe of
+        parent child pairs.
         """
         # Use counters rather than a dataframe, since summing together many.
         n_filtered, all_actual_counts, all_branch_lengths = 0, Counter(), Counter()
         all_pcps = []
         t0 = -time()
         for i, node in enumerate(self.int_nodes, 1):
+            if i % 1000 == 0:
+                print(f"processing node {i}; {t0+time():0.1f} seconds")
+
             count, actual_counts, branch_lens, pcps = self.count_mutations_from_parent(
                 node
             )
@@ -164,15 +224,13 @@ class CountsHelper:
             if count != 0:
                 all_pcps.append(pcps)
 
-            if i % 1000 == 0:
-                print(f"{i} nodes processed in {t0+time():0.1f} seconds")
         all_counts_df = self.mut_counters_to_df(all_actual_counts, all_branch_lengths)
         all_pcps_df = self.pcp_list_to_df(all_pcps)
         return n_filtered, all_counts_df, all_pcps_df
 
     def parallel_count_mutations_on_tree(self, processes=8, batch_size=1000):
         """
-        ...
+        ...would be nice, but not there yet...
         """
         raise NotImplementedError(
             "Can't multiprocess with bte tree, need to do extra book keeping."
@@ -199,6 +257,10 @@ class CountsHelper:
         return n_filtered, all_counts_df
 
     def pcp_list_to_df(self, pcps):
+        """
+        Turn a list of pcps, like those returned by self.count_mutations_from_parent,
+        into a DataFrame.
+        """
         mut_dict = lambda muts: {int(mut[1:-1]): mut[-1] for mut in muts}
         child_seq = lambda seq, muts: apply_muts(seq, mut_dict(muts))
         cols = ["parent_name", "child_name", "parent", "child", "branch_length"]
@@ -218,6 +280,8 @@ class CountsHelper:
         codon_conserv_path,
         tree_size_path,
     ):
+        """Calculate various counts and write to file."""
+
         print(f"Number of nodes in tree: {self.n_nodes}")
         print(f"Number of internal nodes in tree: {self.n_int_nodes}")
 
@@ -270,6 +334,8 @@ def write_counts(
 
 
 if __name__ == "__main__":
+    # In the main hook, so the rest of the file can be imported by other files.
+
     rerooted_tree_paths = snakemake.input.rerooted_tree_paths
     coding_site_paths = snakemake.input.coding_site_paths
     fasta_paths = snakemake.input.fasta_paths


### PR DESCRIPTION
The pipeline now reports counts for all possible mutations from each parent to child. We record the local sequence context of the parent sequence, the mutation count, and the total branch length (number of mutations) where each mutation is possible. Files for pcps are generated for each segment. Stats for the tree for each segment are saved to file.

Results from running this pipeline are at `/fh/fast/matsen_e/shared/flu-syn-rates/recent_results/` (the pcp files are zipped because they're a little large).

