### PR TITLE
Refactor mutation counting to separate host-specific and global tree analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ flu-syn-rates/
 │   │   │   ├── curated_root.fasta
 │   │   │   ├── curated_reference.gff
 │   │   │   ├── curated_reference.gtf
+│   │   │   ├── final_tree.pb.gz          # Global tree (all hosts)
 │   │   │   └── host_specific_trees/
 │   │   │       ├── human_tree.pb.gz
-│   │   │       └── avian_tree.pb.gz
+│   │   │       ├── avian_tree.pb.gz
+│   │   │       └── swine_tree.pb.gz
 │   │   └── H3/
 │   │       └── ...
 │   └── NA/
@@ -78,14 +80,26 @@ Note: Coding sites are shared across all host groups for a given segment/subtype
 
 ### Step 2: Mutation Counting
 
-For each segment, subtype, and host combination, the pipeline:
+The pipeline performs two types of mutation counting:
+
+#### Global Tree Analysis (All Hosts Combined)
+For each segment and subtype combination:
 1. Takes the coding sites file from Step 1
-2. Reads the host-specific phylogenetic tree, reference sequence, and GTF annotation
-3. Traverses the tree to count mutations at each branch
+2. Reads the global phylogenetic tree (`final_tree.pb.gz`), reference sequence, and GTF annotation
+3. Traverses the tree to count mutations at each branch across all hosts
 4. Classifies mutations as synonymous or non-synonymous
-5. Outputs two files per host group:
+5. Outputs two files at the segment/subtype level:
    - `mutation_counts.csv` - Summary of mutations by site and type
    - `parent_child_pairs.csv` - Detailed mutation records for each branch
+
+#### Host-Specific Tree Analysis
+For each segment, subtype, and host combination:
+1. Takes the coding sites file from Step 1
+2. Reads the host-specific phylogenetic tree (`host_specific_trees/{host}_tree.pb.gz`), reference sequence, and GTF annotation
+3. Traverses the tree to count mutations at each branch for that specific host
+4. Classifies mutations as synonymous or non-synonymous
+5. Outputs one file per host group:
+   - `mutation_counts.csv` - Summary of mutations by site and type
 
 ## Running the Pipeline
 
@@ -98,11 +112,14 @@ snakemake --cores <N>
 Or run specific targets:
 
 ```bash
-# Process a specific segment/subtype/host combination
+# Process global tree for a specific segment/subtype
+snakemake --cores 8 results/HA/H1/mutation_counts.csv results/HA/H1/parent_child_pairs.csv
+
+# Process host-specific tree for a specific segment/subtype/host
 snakemake --cores 8 results/HA/H1/human/mutation_counts.csv
 
-# Process all host groups for a specific segment/subtype
-snakemake --cores 8 results/HA/H1/human/mutation_counts.csv results/HA/H1/avian/mutation_counts.csv
+# Process both global and host-specific for a segment/subtype
+snakemake --cores 8 results/HA/H1/mutation_counts.csv results/HA/H1/human/mutation_counts.csv results/HA/H1/avian/mutation_counts.csv
 ```
 
 ## Output Files
@@ -111,13 +128,16 @@ The pipeline generates the following output files:
 
 1. **Coding Sites File**: `results/{segment}/{subtype}/coding_sites.csv`
    - Maps each nucleotide position to its coding properties
-   - Shared across all host groups for a given segment/subtype combination
+   - Shared across all analyses for a given segment/subtype combination
 
-2. **Host-Specific Mutation Count Files**: `results/{segment}/{subtype}/{host}/`
-   - `mutation_counts.csv` - Aggregated mutation counts for the host group
-   - `parent_child_pairs.csv` - Detailed mutation information for the host group
+2. **Global Tree Outputs**: `results/{segment}/{subtype}/`
+   - `mutation_counts.csv` - Aggregated mutation counts across all hosts
+   - `parent_child_pairs.csv` - Detailed branch-level mutation information
 
-3. **Aligned Proteins** (HA and NA only): `results/aligned_proteins/{segment}/`
+3. **Host-Specific Tree Outputs**: `results/{segment}/{subtype}/{host}/`
+   - `mutation_counts.csv` - Aggregated mutation counts for the specific host group
+
+4. **Aligned Proteins** (HA and NA only): `results/aligned_proteins/{segment}/`
    - Cross-subtype protein alignments
 
 Example output structure:
@@ -125,13 +145,15 @@ Example output structure:
 results/
 ├── HA/
 │   ├── H1/
-│   │   ├── coding_sites.csv          # Shared
+│   │   ├── coding_sites.csv                    # Shared
+│   │   ├── mutation_counts.csv                 # Global tree analysis
+│   │   ├── parent_child_pairs.csv              # Global tree PCPs
 │   │   ├── human/
-│   │   │   ├── mutation_counts.csv
-│   │   │   └── parent_child_pairs.csv
-│   │   └── avian/
-│   │       ├── mutation_counts.csv
-│   │       └── parent_child_pairs.csv
+│   │   │   └── mutation_counts.csv            # Host-specific analysis
+│   │   ├── avian/
+│   │   │   └── mutation_counts.csv            # Host-specific analysis
+│   │   └── swine/
+│   │       └── mutation_counts.csv            # Host-specific analysis
 │   └── H3/
 │       └── ...
 └── aligned_proteins/

--- a/Snakefile
+++ b/Snakefile
@@ -10,19 +10,33 @@ def get_subtypes_for_segment(segment):
     else:
         return ["all"]
 
-# Generate all segment-subtype-host combinations
+# Generate all segment-subtype-host combinations for host-specific trees
 segment_subtype_host_combinations = []
 for segment in config["segments"]:
     for subtype in get_subtypes_for_segment(segment):
         for host in config["host_groups"]:
             segment_subtype_host_combinations.append((segment, subtype, host))
 
+# Generate all segment-subtype combinations for global trees
+segment_subtype_combinations = []
+for segment in config["segments"]:
+    for subtype in get_subtypes_for_segment(segment):
+        segment_subtype_combinations.append((segment, subtype))
+
 # Final output files
 final_outputs = []
+
+# Add host-specific mutation counts (no PCPs)
 for segment, subtype, host in segment_subtype_host_combinations:
+    final_outputs.append(
+        f"{config['output_dir']}/{segment}/{subtype}/{host}/mutation_counts.csv"
+    )
+
+# Add global mutation counts and PCPs
+for segment, subtype in segment_subtype_combinations:
     final_outputs.extend([
-        f"{config['output_dir']}/{segment}/{subtype}/{host}/mutation_counts.csv",
-        f"{config['output_dir']}/{segment}/{subtype}/{host}/parent_child_pairs.csv"
+        f"{config['output_dir']}/{segment}/{subtype}/mutation_counts.csv",
+        f"{config['output_dir']}/{segment}/{subtype}/parent_child_pairs.csv"
     ])
 
 # Add aligned proteins outputs (only for HA and NA segments)
@@ -56,18 +70,39 @@ rule make_coding_sites:
             --output_directory {wildcards.output_dir}/{wildcards.segment}/{wildcards.subtype} &> {log}
         """
 
-# Count mutations along tree
-rule count_mutations:
+# Count mutations along host-specific trees
+rule count_mutations_host_trees:
     input:
         tree_path=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/host_specific_trees/{wildcards.host}_tree.pb.gz",
         coding_site_path=rules.make_coding_sites.output.coding_sites,
         fasta_path=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/curated_root.fasta",
         gtf_path=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/curated_reference.gtf"
     output:
-        all_counts_path="{output_dir}/{segment}/{subtype}/{host}/mutation_counts.csv",
-        all_pcps_path="{output_dir}/{segment}/{subtype}/{host}/parent_child_pairs.csv"
+        all_counts_path="{output_dir}/{segment}/{subtype}/{host}/mutation_counts.csv"
     log:
         "logs/{output_dir}/{segment}_{subtype}_{host}_mutation_counts.log"
+    shell:
+        """
+        python scripts/make_count_dfs.py \
+            --tree_path {input.tree_path} \
+            --coding_site_path {input.coding_site_path} \
+            --fasta_path {input.fasta_path} \
+            --gtf_path {input.gtf_path} \
+            --all_counts_path {output.all_counts_path} &> {log}
+        """
+
+# Count mutations along global (non-host-specific) trees
+rule count_mutations:
+    input:
+        tree_path=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/final_tree.pb.gz",
+        coding_site_path=rules.make_coding_sites.output.coding_sites,
+        fasta_path=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/curated_root.fasta",
+        gtf_path=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/curated_reference.gtf"
+    output:
+        all_counts_path="{output_dir}/{segment}/{subtype}/mutation_counts.csv",
+        all_pcps_path="{output_dir}/{segment}/{subtype}/parent_child_pairs.csv"
+    log:
+        "logs/{output_dir}/{segment}_{subtype}_mutation_counts.log"
     shell:
         """
         python scripts/make_count_dfs.py \

--- a/scripts/make_count_dfs.py
+++ b/scripts/make_count_dfs.py
@@ -282,7 +282,8 @@ class CountsHelper:
         print(f"Number of nodes passing filter: {n_passing_filters}")
 
         all_counts_df.to_csv(all_counts_path, index=False)
-        all_pcps_df.to_csv(all_pcps_path, index=False)
+        if all_pcps_path is not None:
+            all_pcps_df.to_csv(all_pcps_path, index=False)
 
         return None
 
@@ -294,7 +295,7 @@ def main():
     parser.add_argument('--fasta_path', required=True, help='Path to reference FASTA file')
     parser.add_argument('--gtf_path', required=True, help='Path to GTF annotation file')
     parser.add_argument('--all_counts_path', required=True, help='Output path for mutation counts CSV')
-    parser.add_argument('--all_pcps_path', required=True, help='Output path for parent-child pairs CSV')
+    parser.add_argument('--all_pcps_path', required=False, default=None, help='Output path for parent-child pairs CSV (optional)')
     
     # Parse arguments
     args = parser.parse_args()


### PR DESCRIPTION
This PR implements the changes described in #20 to separate host-specific and global tree mutation counting.

## Changes

### 1. Python Script (`scripts/make_count_dfs.py`)
- Made `--all_pcps_path` argument optional
- Only writes parent-child pairs CSV when path is provided

### 2. Snakefile
- **Renamed:** `count_mutations` → `count_mutations_host_trees`
- **Host-specific analysis:** Processes `host_specific_trees/{host}_tree.pb.gz`, outputs only `mutation_counts.csv`
- **New `count_mutations` rule:** Processes `final_tree.pb.gz`, outputs both `mutation_counts.csv` and `parent_child_pairs.csv`
- **Updated output collection:** Handles both analysis types with separate combination lists

### 3. README.md
- Documents both global and host-specific tree analysis workflows
- Updated directory structure to show `final_tree.pb.gz`
- Updated output structure examples
- Updated command examples for both analysis types

## Benefits

- **Reduces disk usage:** Eliminates large redundant PCP files in host-specific directories
- **Comprehensive global analysis:** Full PCP data available at segment/subtype level
- **Clear separation:** Distinct workflows for host-specific vs cross-host analyses

## Output Structure

```
results/
├── HA/H1/
│   ├── mutation_counts.csv          # Global tree
│   ├── parent_child_pairs.csv       # Global tree (with PCPs)
│   ├── human/
│   │   └── mutation_counts.csv     # Host-specific (no PCPs)
│   ├── avian/
│   │   └── mutation_counts.csv     # Host-specific (no PCPs)
│   └── swine/
│       └── mutation_counts.csv     # Host-specific (no PCPs)
```

## Verification

Dry-run confirms:
- ✅ 14 `count_mutations` jobs (global trees)
- ✅ 42 `count_mutations_host_trees` jobs (host-specific)
- ✅ No rule conflicts

## Testing Checklist

- [ ] Test script without `--all_pcps_path` argument
- [ ] Test script with `--all_pcps_path` argument
- [ ] Dry-run shows both rules recognized
- [ ] Test global tree analysis for single segment
- [ ] Test host-specific analysis
- [ ] Verify no PCP files created in host directories
- [ ] Verify PCP files created at segment/subtype level
- [ ] Full pipeline run

Closes #20