### PR TITLE
Add optional per-segment gene ignore list to make_coding_sites

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -103,6 +103,10 @@ rule make_coding_sites:
         coding_sites="{output_dir}/{segment}/{subtype}/coding_sites.csv"
     log:
         "logs/{output_dir}/{segment}_{subtype}_coding_sites.log"
+    params:
+        ignore_genes=lambda wildcards: " ".join(
+            config.get("ignore_genes", {}).get(wildcards.segment, [])
+        )
     shell:
         """
         python scripts/make_coding_sites.py \
@@ -110,7 +114,8 @@ rule make_coding_sites:
             --gff_file {input.gff_file} \
             --subtype {wildcards.subtype} \
             --segment {wildcards.segment} \
-            --output_directory {wildcards.output_dir}/{wildcards.segment}/{wildcards.subtype} &> {log}
+            --output_directory {wildcards.output_dir}/{wildcards.segment}/{wildcards.subtype} \
+            --ignore_genes {params.ignore_genes} &> {log}
         """
 
 # Count mutations along host-specific trees

--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,8 @@ host_groups:
 # Data directory paths
 data_dir: "../flu-usher/results"
 output_dir: "results"
+
+# Optional: genes to ignore in specific segments during coding site creation
+ignore_genes:
+  PB1:
+    - "PB1-F2"

--- a/scripts/make_coding_sites.py
+++ b/scripts/make_coding_sites.py
@@ -16,6 +16,8 @@ def main():
     parser.add_argument('--gff_file', required=True, help='Path to GFF annotation file')
     parser.add_argument('--subtype', required=True, help='Influenza subtype (e.g., H1N1, H3N2)')
     parser.add_argument('--segment', required=True, help='Gene segment (e.g., HA, NA)')
+    parser.add_argument('--ignore_genes', nargs='*', default=[],
+                        help='Gene names to exclude from coding site mapping (e.g. PB1-F2)')
     args = parser.parse_args()
 
     # Read in the reference sequence from the FASTA file, assuming it is the first sequence
@@ -60,6 +62,10 @@ def main():
                 'strand': cdss[0][2]  # Assume all CDSs have same strand
             }
     
+    if args.ignore_genes:
+        genes_info = {name: data for name, data in genes_info.items() if name not in args.ignore_genes}
+        print(f"Ignoring genes: {args.ignore_genes}")
+
     print(f"Found {len(genes_info)} genes: {list(genes_info.keys())}")
     
     # Create output directory and protein sequences subdirectory if they don't exist


### PR DESCRIPTION
## Summary

- Adds an optional `ignore_genes` key to `config.yaml` mapping segment names to lists of gene names to skip during coding site creation
- Adds a `params` block to the `make_coding_sites` Snakemake rule to pass ignored genes to the script
- Adds `--ignore_genes` argument to `scripts/make_coding_sites.py` to filter genes before any downstream processing

Currently configured to ignore `PB1-F2` in the PB1 segment.

Closes #28

## Test plan

- [ ] Dry-run: `snakemake -np results/PB1/all/coding_sites.csv` — confirm `--ignore_genes PB1-F2` appears in the shell command
- [ ] Run: `snakemake --forcerun make_coding_sites --cores 4 results/PB1/all/coding_sites.csv`
- [ ] Verify: `grep "PB1-F2" results/PB1/all/coding_sites.csv` returns no matches
- [ ] Verify other segments unaffected (e.g. `results/HA/H1/coding_sites.csv` includes all HA genes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)