### PR TITLE
Use motif-specific rates for CG/GC augmentation when available

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -233,6 +233,7 @@ rule augment_expected_rates:
     input:
         script="scripts/augment_expected_rates.py",
         segment_wide_rates="{output_dir}/segment_wide_rates.csv",
+        motif_level_rates="{output_dir}/motif_level_genome_wide_rates.csv",
         full_expected="{output_dir}/neutral_model/local_context+global_context/expected_rates_by_predictor.csv"
     output:
         expected_rates="{output_dir}/expected_rates.csv"
@@ -242,6 +243,7 @@ rule augment_expected_rates:
         """
         python {input.script} \
             --segment_wide_rates {input.segment_wide_rates} \
+            --motif_level_rates {input.motif_level_rates} \
             --input_file {input.full_expected} \
             --output_file {output.expected_rates} &> {log}
         """

--- a/scripts/augment_expected_rates.py
+++ b/scripts/augment_expected_rates.py
@@ -18,6 +18,16 @@ def load_segment_rates(filepath):
     return filtered[['mut_type', 'segment', 'rate']]
 
 
+def load_motif_rates(filepath):
+    """Load motif-level genome-wide rates for CG/GC, host=='all'.
+
+    Returns a dict keyed by (mut_type, motif) -> rate.
+    """
+    df = pd.read_csv(filepath, keep_default_na=False)
+    filtered = df.query("mut_type in ['CG', 'GC'] and host == 'all'")
+    return dict(zip(zip(filtered['mut_type'], filtered['motif']), filtered['rate']))
+
+
 def generate_motifs(mut_type):
     """
     Generate all 16 possible 3-mer motifs for a mutation type.
@@ -29,14 +39,18 @@ def generate_motifs(mut_type):
     return sorted(motifs)
 
 
-def augment_full_model(df_existing, segment_rates):
-    """Augment full model with CG and GC entries (16 motifs × 8 segments each)."""
+def augment_full_model(df_existing, segment_rates, motif_rates):
+    """Augment full model with CG and GC entries (16 motifs × 8 segments each).
+
+    For each motif, uses the motif-specific genome-wide rate if available in
+    motif_rates, otherwise falls back to the segment-wide average rate.
+    """
     # Segment order matching rates_model.py
     segments = ['PB1', 'NS', 'NA', 'HA', 'PB2', 'MP', 'PA', 'NP']
 
     new_rows = []
     for mut_type in ['CG', 'GC']:
-        # Get segment-specific rates
+        # Get segment-specific rates (used as fallback)
         mut_rates = segment_rates[segment_rates['mut_type'] == mut_type]
 
         # Generate motifs
@@ -49,9 +63,9 @@ def augment_full_model(df_existing, segment_rates):
                 print(f"Warning: No rate found for {mut_type} in {segment}, skipping segment")
                 continue
 
-            rate = segment_rate[0]
-
             for motif in motifs:
+                # Use motif-specific rate if available, else fall back to segment rate
+                rate = motif_rates.get((mut_type, motif), segment_rate[0])
                 new_rows.append({
                     'mut_type': mut_type,
                     'segment': segment,
@@ -72,6 +86,8 @@ def main():
     )
     parser.add_argument('--segment_wide_rates', required=True,
                        help='Path to segment_wide_rates.csv')
+    parser.add_argument('--motif_level_rates', required=True,
+                       help='Path to motif_level_genome_wide_rates.csv')
     parser.add_argument('--input_file', required=True,
                        help='Path to full model expected_rates_by_predictor.csv')
     parser.add_argument('--output_file', required=True,
@@ -106,12 +122,24 @@ def main():
 
     print(f"Found CG and GC rates for all 8 segments")
 
+    # Load motif-level rates
+    print(f"\nLoading motif-level rates from {args.motif_level_rates}")
+    try:
+        motif_rates = load_motif_rates(args.motif_level_rates)
+    except FileNotFoundError:
+        print(f"Error: File not found: {args.motif_level_rates}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error loading motif_level_rates: {e}")
+        sys.exit(1)
+    print(f"  Loaded {len(motif_rates)} motif-specific CG/GC rates")
+
     # Load and augment full model
     print(f"\nLoading full model from: {args.input_file}")
     try:
         df_full = pd.read_csv(args.input_file, keep_default_na=False)
         print(f"  Original rows: {len(df_full)}")
-        df_full_aug = augment_full_model(df_full, segment_rates)
+        df_full_aug = augment_full_model(df_full, segment_rates, motif_rates)
         print(f"  Augmented rows: {len(df_full_aug)}")
         df_full_aug.to_csv(args.output_file, index=False)
         print(f"  Saved to {args.output_file}")


### PR DESCRIPTION
Closes #30

## Summary
- `augment_expected_rates.py` now loads motif-level genome-wide rates from `motif_level_genome_wide_rates.csv` and uses them preferentially over the segment-wide average for CG and GC motifs
- 24 motif-specific rates are used (12 for CG, 12 for GC); the 4 motifs per type with no observed data (ACA/ACC/ACG/ACT for CG; AGA/AGC/AGG/AGT for GC) fall back to the segment-wide rate as before
- `Snakefile` updated to pass `motif_level_genome_wide_rates.csv` as an input to the `augment_expected_rates` rule

## Test plan
- [ ] Script runs end-to-end: `python scripts/augment_expected_rates.py --segment_wide_rates results/segment_wide_rates.csv --motif_level_rates results/motif_level_genome_wide_rates.csv --input_file results/neutral_model/local_context+global_context/expected_rates_by_predictor.csv --output_file /tmp/test.csv`
- [ ] Motif with data (e.g. CG/GCA) uses motif-specific rate, not segment average
- [ ] Motif without data (e.g. CG/ACA) falls back to segment-wide rate
- [ ] All validation checks pass (128 entries per mut_type, 16 per mut_type×segment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)