### PR TITLE
Add process_shapemap_data notebook to Snakemake pipeline

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -44,6 +44,9 @@ for segment in config["segments"]:
     for subtype in get_subtypes_for_segment(segment):
         segment_subtype_combinations.append((segment, subtype))
 
+# Segments used in SHAPE-MaP analysis (HA and NA excluded per the notebook)
+shapemap_segments = [s for s in config["segments"] if s not in ["HA", "NA"]]
+
 # Final output files
 final_outputs = []
 
@@ -88,6 +91,9 @@ final_outputs.extend([
     f"{config['output_dir']}/neutral_model/local_context+global_context/model_performance.csv",
     f"{config['output_dir']}/expected_rates.csv"
 ])
+
+# Add SHAPE-MaP processed data to final targets
+final_outputs.append(f"{config['output_dir']}/shapemap/all_data.csv")
 
 # Main rule to define target outputs
 rule all:
@@ -246,6 +252,31 @@ rule augment_expected_rates:
             --motif_level_rates {input.motif_level_rates} \
             --input_file {input.full_expected} \
             --output_file {output.expected_rates} &> {log}
+        """
+
+# Process SHAPE-MaP reactivity data and align to reference sequences
+rule process_shapemap_data:
+    input:
+        excel="data/dadonaite_2019/41564_2019_513_MOESM3_ESM.xlsx",
+        ref_fastas=expand(
+            "{data_dir}/{segment}/all/curated_reference.fasta",
+            data_dir=config["data_dir"],
+            segment=shapemap_segments
+        )
+    output:
+        "{output_dir}/shapemap/all_data.csv"
+    params:
+        data_dir=config["data_dir"]
+    log:
+        "logs/{output_dir}/process_shapemap_data.log"
+    shell:
+        """
+        data_dir=$(realpath {params.data_dir}) && \
+        cd notebooks && \
+        papermill \
+            process_shapemap_data.ipynb \
+            process_shapemap_data.ipynb \
+            -p data_dir $data_dir &> ../{log}
         """
 
 # Align protein sequences across subtypes (only for HA and NA)

--- a/notebooks/process_shapemap_data.ipynb
+++ b/notebooks/process_shapemap_data.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "787340d7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.015056,
+     "end_time": "2026-02-25T01:37:38.391448",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:38.376392",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Process SHAPE-MaP data"
    ]
@@ -11,7 +20,16 @@
   {
    "cell_type": "markdown",
    "id": "c3d97333",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.013492,
+     "end_time": "2026-02-25T01:37:38.418228",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:38.404736",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Import Python modules"
    ]
@@ -20,7 +38,22 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "7fd17baf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:38.445434Z",
+     "iopub.status.busy": "2026-02-25T01:37:38.444295Z",
+     "iopub.status.idle": "2026-02-25T01:37:43.814198Z",
+     "shell.execute_reply": "2026-02-25T01:37:43.812889Z"
+    },
+    "papermill": {
+     "duration": 5.386472,
+     "end_time": "2026-02-25T01:37:43.817011",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:38.430539",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -41,18 +74,97 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a1b2c3d4e5f6a7b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:43.844798Z",
+     "iopub.status.busy": "2026-02-25T01:37:43.844050Z",
+     "iopub.status.idle": "2026-02-25T01:37:43.850197Z",
+     "shell.execute_reply": "2026-02-25T01:37:43.848818Z"
+    },
+    "papermill": {
+     "duration": 0.022175,
+     "end_time": "2026-02-25T01:37:43.852588",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:43.830413",
+     "status": "completed"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "data_dir = \"../../flu-usher/results\"  # default for interactive use\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b0949fab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:43.878133Z",
+     "iopub.status.busy": "2026-02-25T01:37:43.877613Z",
+     "iopub.status.idle": "2026-02-25T01:37:43.883411Z",
+     "shell.execute_reply": "2026-02-25T01:37:43.882139Z"
+    },
+    "papermill": {
+     "duration": 0.033608,
+     "end_time": "2026-02-25T01:37:43.898341",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:43.864733",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "data_dir = \"/fh/fast/matsen_e/hhaddox/2025/flu-usher/results\"\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "18ea2d27",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011425,
+     "end_time": "2026-02-25T01:37:43.927966",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:43.916541",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Read in reactivity scores from each experiment"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "61e9d86c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:43.960898Z",
+     "iopub.status.busy": "2026-02-25T01:37:43.960409Z",
+     "iopub.status.idle": "2026-02-25T01:37:46.248056Z",
+     "shell.execute_reply": "2026-02-25T01:37:46.246996Z"
+    },
+    "papermill": {
+     "duration": 2.305174,
+     "end_time": "2026-02-25T01:37:46.250114",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:43.944940",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -201,7 +313,7 @@
        "[67174 rows x 5 columns]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -259,16 +371,40 @@
   {
    "cell_type": "markdown",
    "id": "65c0ab2c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011676,
+     "end_time": "2026-02-25T01:37:46.276671",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:46.264995",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Read in sequences"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "93d71603",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:46.302653Z",
+     "iopub.status.busy": "2026-02-25T01:37:46.302440Z",
+     "iopub.status.idle": "2026-02-25T01:37:46.369971Z",
+     "shell.execute_reply": "2026-02-25T01:37:46.368985Z"
+    },
+    "papermill": {
+     "duration": 0.083093,
+     "end_time": "2026-02-25T01:37:46.372249",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:46.289156",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -583,7 +719,7 @@
        "63  AGCAAAAGCAGGGTGACAAAGACATAATGGATTCCAACACTGTGTC...  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,16 +756,40 @@
   {
    "cell_type": "markdown",
    "id": "0ec81c55",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.012807,
+     "end_time": "2026-02-25T01:37:46.398519",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:46.385712",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "For each segment, write a FASTA file with the sequences from each experiment and the reference sequence used to build trees. Then align the sequences."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "84adffdd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:46.430301Z",
+     "iopub.status.busy": "2026-02-25T01:37:46.429891Z",
+     "iopub.status.idle": "2026-02-25T01:37:46.532905Z",
+     "shell.execute_reply": "2026-02-25T01:37:46.531545Z"
+    },
+    "papermill": {
+     "duration": 0.122321,
+     "end_time": "2026-02-25T01:37:46.535316",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:46.412995",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -655,7 +815,7 @@
     "    print(segment)\n",
     "\n",
     "    # Read in reference sequence and update its record ID to be reference\n",
-    "    ref_fasta = f'../../flu-usher/results/{segment}/all/curated_reference.fasta'\n",
+    "    ref_fasta = f'{data_dir}/{segment}/all/curated_reference.fasta'\n",
     "    ref_record = next(SeqIO.parse(ref_fasta, 'fasta'))\n",
     "    ref_record.id = 'reference'\n",
     "    ref_record.description = ''\n",
@@ -692,16 +852,40 @@
   {
    "cell_type": "markdown",
    "id": "25bf33e4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.013981,
+     "end_time": "2026-02-25T01:37:46.562770",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:46.548789",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Read in alignments, record numbering information relative to reference, and plot percent identities between sequences."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "f02358f9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:46.595166Z",
+     "iopub.status.busy": "2026-02-25T01:37:46.594067Z",
+     "iopub.status.idle": "2026-02-25T01:37:48.203159Z",
+     "shell.execute_reply": "2026-02-25T01:37:48.202140Z"
+    },
+    "papermill": {
+     "duration": 1.627697,
+     "end_time": "2026-02-25T01:37:48.205426",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:46.577729",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -837,7 +1021,16 @@
   {
    "cell_type": "markdown",
    "id": "af86d400",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.017739,
+     "end_time": "2026-02-25T01:37:48.251938",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:48.234199",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Add sequence and numbering information to the dataframe with reactivities."
    ]
@@ -846,7 +1039,22 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "314bff4f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-25T01:37:48.289101Z",
+     "iopub.status.busy": "2026-02-25T01:37:48.288718Z",
+     "iopub.status.idle": "2026-02-25T01:37:48.857253Z",
+     "shell.execute_reply": "2026-02-25T01:37:48.856514Z"
+    },
+    "papermill": {
+     "duration": 0.590991,
+     "end_time": "2026-02-25T01:37:48.859461",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:48.268470",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1074,102 +1282,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07015db3",
-   "metadata": {},
+   "id": "83bd3e73",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016582,
+     "end_time": "2026-02-25T01:37:48.901295",
+     "exception": false,
+     "start_time": "2026-02-25T01:37:48.884713",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f01801d2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Read in sheet 2 from excel file\n",
-    "df = pd.read_excel('../data/dadonaite_2019/41564_2019_513_MOESM3_ESM.xlsx', sheet_name=2)\n",
-    "\n",
-    "# Add a column giving the site on the negative strand\n",
-    "df['site_neg_strand'] = df.index + 1\n",
-    "sites = df['site_neg_strand'].values\n",
-    "df.set_index('site_neg_strand', inplace=True)\n",
-    "\n",
-    "# Transpose dataframe and then add columns giving metadata\n",
-    "df = (\n",
-    "    df\n",
-    "    .T\n",
-    "    .reset_index()\n",
-    "    .rename(columns={'index':'experiment'})\n",
-    "    .query('experiment.str.contains(\"A/WSN/\")')\n",
-    ")\n",
-    "\n",
-    "def parse_metadata(experiment):\n",
-    "    parts = experiment.split()\n",
-    "    if len(parts) == 4:\n",
-    "        (strain, segment, substrate, replicate) = parts\n",
-    "    elif len(parts) == 3:\n",
-    "        (strain, segment, substrate) = parts\n",
-    "        replicate = 1\n",
-    "    else:\n",
-    "        raise ValueError(f\"Unexpected experiment format: {experiment}\")\n",
-    "    return (strain, segment, substrate, replicate)\n",
-    "\n",
-    "df['strain'], df['segment'], df['substrate'], df['replicate'] = zip(*df['experiment'].map(parse_metadata))\n",
-    "\n",
-    "# Make a long-form dataframe with data averaged across replicates\n",
-    "id_vars = ['experiment', 'strain', 'segment', 'substrate', 'replicate']\n",
-    "reactivity_df = (\n",
-    "    pd.melt(df, id_vars=id_vars, value_name='reactivity')\n",
-    "    .query('reactivity.notnull()')\n",
-    ")\n",
-    "\n",
-    "# Read in the sequences used in the experiments\n",
-    "seq_df = pd.read_excel('../data/dadonaite_2019/41564_2019_513_MOESM3_ESM.xlsx', sheet_name=1)\n",
-    "seq_df.rename(columns = {\n",
-    "    'Source Name' : 'experiment',\n",
-    "    'Characteristics[Nucleotide Sequence]' : 'sequence'\n",
-    "}, inplace=True)\n",
-    "seq_df = seq_df.dropna(subset=['experiment', 'sequence'])[['experiment', 'sequence']]\n",
-    "\n",
-    "# Convert dataframe to a dictionary mapping experiment to sequence\n",
-    "assert seq_df['experiment'].is_unique, \"Experiments are not unique in sequence dataframe\"\n",
-    "full_seq_dict = dict(zip(seq_df['experiment'], seq_df['sequence']))\n",
-    "\n",
-    "# Make a dataframe with one row per site in each experiment, giving the nucleotide at that site,\n",
-    "# as well as the corresponding site number and nucleotide on the positive strand\n",
-    "seq_dict = defaultdict(list)\n",
-    "for (i, row) in seq_df.iterrows():\n",
-    "    seq_len = len(row['sequence'])\n",
-    "    for (n, nt) in enumerate(row['sequence'], 1):\n",
-    "        seq_dict['experiment'].append(row['experiment'])\n",
-    "        seq_dict['site_neg_strand'].append(n)\n",
-    "        seq_dict['wt_nt_neg_strand'].append(nt)\n",
-    "        seq_dict['site_pos_strand'].append(seq_len - n + 1)\n",
-    "        seq_dict['wt_nt_pos_strand'].append(str(Seq(nt).reverse_complement()))\n",
-    "\n",
-    "# Merge the sequence/numbering dataframe into the reactivity dataframe\n",
-    "reactivity_df = reactivity_df.merge(pd.DataFrame(seq_dict), on=['experiment', 'site_neg_strand'])\n",
-    "\n",
-    "# Average reactivities across replicates and drop rows with missing data\n",
-    "groupby_cols = [\n",
-    "    'strain', 'segment', 'substrate', 'site_neg_strand', 'wt_nt_neg_strand',\n",
-    "    'site_pos_strand', 'wt_nt_pos_strand',\n",
-    "]\n",
-    "pivot_index_cols = groupby_cols.copy()\n",
-    "pivot_index_cols.remove('substrate')\n",
-    "reactivity_df = (\n",
-    "    reactivity_df\n",
-    "    .query('reactivity > -998')\n",
-    "    .groupby(groupby_cols, as_index=False)['reactivity'].mean()\n",
-    "    .pivot_table(index=pivot_index_cols, columns='substrate', values='reactivity')\n",
-    "    .rename(columns={col: f'reactivity_{col}' for col in reactivity_df['substrate'].unique()})\n",
-    "    .reset_index()\n",
-    "    .rename_axis(columns=None)\n",
-    "    .rename(columns={'site_pos_strand':'site', 'wt_nt_pos_strand':'wt_nt_exp'})\n",
-    ")\n",
-    "\n",
-    "reactivity_df.head()"
-   ]
   }
  ],
  "metadata": {
@@ -1189,6 +1314,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.18"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 16.813187,
+   "end_time": "2026-02-25T01:37:49.435278",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "process_shapemap_data.ipynb",
+   "output_path": "process_shapemap_data.ipynb",
+   "parameters": {
+    "data_dir": "/fh/fast/matsen_e/hhaddox/2025/flu-usher/results"
+   },
+   "start_time": "2026-02-25T01:37:32.622091",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #32

## Summary

- Adds a `parameters`-tagged cell to `process_shapemap_data.ipynb` with `data_dir = "../../flu-usher/results"` as default (preserves interactive use from `notebooks/`)
- Replaces the hardcoded flu-usher path with the `data_dir` variable
- Adds a `process_shapemap_data` Snakemake rule that uses `papermill` to inject `data_dir` from config (resolved to absolute path via `realpath` before `cd notebooks`)
- Appends `results/shapemap/all_data.csv` to `final_outputs`

## Test plan

- [ ] `snakemake -np results/shapemap/all_data.csv` shows only the shapemap rule
- [ ] `snakemake --cores 4 --forcerun process_shapemap_data results/shapemap/all_data.csv` runs successfully and produces `results/shapemap/all_data.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)