### PR TITLE
Add syn_branch_length column to mutation counts output

### DIFF
--- a/scripts/make_count_dfs.py
+++ b/scripts/make_count_dfs.py
@@ -143,8 +143,8 @@ class CountsHelper:
             return m if len(m) == 3 else pd.NA
         counts_df["parent_motif"] = counts_df.site.apply(parent_motif)
         counts_df["actual_count"] = 0
-        counts_df["branch_length"] = 0
         pcps = (parent.id, parent_seq, [])
+        n_passing_muts = 0
 
         # Initialize filter statistics
         filter_stats = {
@@ -187,12 +187,19 @@ class CountsHelper:
             filter_stats['passing_mutations'] += num_muts
 
             pcps[2].append((node.id, nt_muts))
-            counts_df["branch_length"] += len(nt_muts)
+            n_passing_muts += len(nt_muts)
             to_increment = counts_df.query("nt_mut.isin(@node.mutations)").index
             counts_df.loc[to_increment, "actual_count"] += 1
 
-        syn_actual_count = counts_df.loc[counts_df['wt_aa'] == counts_df['mut_aa'], 'actual_count'].sum()
-        counts_df["syn_branch_length"] = syn_actual_count
+        branch_length = counts_df['actual_count'].sum()
+        assert branch_length == n_passing_muts, \
+            f"branch_length ({branch_length}) != n_passing_muts ({n_passing_muts})"
+        counts_df["branch_length"] = branch_length
+        # Count synonymous mutations by checking wt_aa == mut_aa. This is valid because
+        # we already filtered out branches where two mutations target the same codon, so
+        # each nucleotide mutation affects a distinct codon and can be classified
+        # independently as synonymous or non-synonymous.
+        counts_df["syn_branch_length"] = counts_df[counts_df['wt_aa'] == counts_df['mut_aa']]['actual_count'].sum()
 
         return n_passing_filters, counts_df, pcps, filter_stats
 

--- a/scripts/make_count_dfs.py
+++ b/scripts/make_count_dfs.py
@@ -191,6 +191,9 @@ class CountsHelper:
             to_increment = counts_df.query("nt_mut.isin(@node.mutations)").index
             counts_df.loc[to_increment, "actual_count"] += 1
 
+        syn_actual_count = counts_df.loc[counts_df['wt_aa'] == counts_df['mut_aa'], 'actual_count'].sum()
+        counts_df["syn_branch_length"] = syn_actual_count
+
         return n_passing_filters, counts_df, pcps, filter_stats
 
     def count_mutations_on_tree(self, max_mutations=4):
@@ -256,7 +259,8 @@ class CountsHelper:
                     .groupby(cols, as_index=False)
                     .agg({
                         'actual_count' : 'sum',
-                        'branch_length' : 'sum'
+                        'branch_length' : 'sum',
+                        'syn_branch_length' : 'sum'
                     })
                 )
 


### PR DESCRIPTION
## Summary

- Adds a `syn_branch_length` column to the `mutation_counts.csv` output, recording the total number of synonymous nucleotide mutations across all passing branches for each parent node
- Derived post-hoc from `actual_count` using the identity: `sum(actual_count where wt_aa == mut_aa)` = synonymous branch length
- Like `branch_length`, the value is uniform across all rows for a given parent batch and is correctly summed in the cross-node aggregation

## Test plan

- [ ] Confirm `syn_branch_length` column is present in output CSV
- [ ] Confirm `syn_branch_length` ≤ `branch_length` for all rows
- [ ] Confirm `syn_branch_length` is non-negative

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)