### PR TITLE
Wire protein_sequences/ into the Snakemake DAG (fixes #78)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -181,7 +181,8 @@ rule make_coding_sites:
         ref_fasta=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/curated_root.fasta",
         gff_file=lambda wildcards: f"{config['data_dir']}/{wildcards.segment}/{wildcards.subtype}/curated_reference.gff"
     output:
-        coding_sites="{output_dir}/{segment}/{subtype}/coding_sites.csv"
+        coding_sites="{output_dir}/{segment}/{subtype}/coding_sites.csv",
+        protein_sequences=directory("{output_dir}/{segment}/{subtype}/protein_sequences")
     log:
         "{output_dir}/logs/{segment}/{subtype}/coding_sites.log"
     params:
@@ -648,6 +649,10 @@ rule align_proteins:
     input:
         # Ensure all coding sites files are created first for this segment
         coding_sites=lambda wildcards: expand("{output_dir}/{segment}/{subtype}/coding_sites.csv",
+                          output_dir=config["output_dir"],
+                          segment=wildcards.segment,
+                          subtype=get_subtypes_for_segment(wildcards.segment)),
+        protein_sequences=lambda wildcards: expand("{output_dir}/{segment}/{subtype}/protein_sequences",
                           output_dir=config["output_dir"],
                           segment=wildcards.segment,
                           subtype=get_subtypes_for_segment(wildcards.segment))


### PR DESCRIPTION
## Summary

- Declares `protein_sequences=directory(...)` as an output of `make_coding_sites` and as an input of `align_proteins`, so Snakemake actually enforces the dependency that `scripts/align_proteins.py` relies on.
- Resolves the runtime failure `Error: Directory results/HA/H1/protein_sequences does not exist` seen in `results/logs/HA/align_proteins.log`.

## Why

`scripts/make_coding_sites.py` produces two artifacts — `coding_sites.csv` and a sibling `protein_sequences/` directory of per-gene FASTA files — but the rule only declared the CSV. `scripts/align_proteins.py` reads from `protein_sequences/`, yet `align_proteins` only declared the CSVs as input. When `protein_sequences/` was missing alongside an up-to-date CSV (cleanup, copy-in from an older run, or script change post-dating the CSVs), Snakemake skipped `make_coding_sites` and `align_proteins` failed.

Fixes #78.

## Test plan

- [x] `snakemake -np results/aligned_proteins/HA` shows the expected 5×`make_coding_sites` + 1×`align_proteins` jobs.
- [x] `snakemake --cores 8 results/aligned_proteins/HA` succeeds; `results/aligned_proteins/HA/HA_aligned.fasta` is produced; `results/logs/HA/align_proteins.log` no longer reports the missing-directory error.
- [x] Same verification for NA (`results/aligned_proteins/NA/NA_aligned.fasta`).

## Heads-up

Re-running `make_coding_sites` rewrites `results/{HA,NA}/{subtype}/coding_sites.csv` (identical content, new mtime), which marks downstream `mutation_counts.csv` for those segments as stale. Use `snakemake --touch` on those downstream outputs if you want to avoid a cascade rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)