### PR TITLE
Add bovine host group (counts, PCPs, fitness effects; excluded from plots)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ results/
    - Input data directory (`../flu-usher/results`)
    - HA subtypes: H1, H3, H5, H7, H9
    - NA subtypes: N1, N2, N6, N8, N9
-   - Host groups: human, avian, swine
+   - Host groups: human, avian, swine, bovine
    - Geographic groups: north_america, europe, asia
    - Split-half groups: split_a, split_b (random branch partition for robustness)
    - Split-half seed: integer seed for the partition (reproducible)

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ host_groups:
   - "human"
   - "avian"
   - "swine"
+  - "bovine"
 
 geographic_groups:
   - "north_america"


### PR DESCRIPTION
## Summary

Adds `bovine` as a host group so the pipeline produces host-stratified **mutation counts**, **parent-child pairs (PCPs)**, and **amino-acid fitness effects** for bovine influenza branches, alongside human/avian/swine. Motivated by the 2024–2025 H5 cattle outbreak.

Bovine is **computed but excluded from downstream plots** per the design discussion.

## Changes

- **`config.yaml`** — add `bovine` to `host_groups`. This is the only wiring needed: the Snakefile, `make_count_dfs.py`, and the `compute_*` notebooks all read `host_groups` dynamically, and the upstream `host_ancestral/combined_ancestral_states.tab` already uses the exact label `bovine` (present in 8 segments/subtypes; H1/H3 have none and simply get no bovine output).
- **`notebooks/analyze_subset_fitness_effects.ipynb`** — the one downstream notebook that builds comparisons dynamically. Added an `exclude_subsets = {'Bovine'}` filter before pair generation so bovine is dropped from the scatter grid, the R-per-protein chart, and the cutoff-sweep chart, while it remains in `subset_aa_fitness_effects.csv`. (`'Bovine'` is title-cased to match the in-notebook subset names.)
- **`CLAUDE.md`** — host-group enumeration updated to include bovine.

No changes needed to `analyze_genome_wide_rates.ipynb` or the aa/nt heatmap dashboards — they hardcode the legacy host lists and already omit bovine.

## Verification (run after merge)

1. `snakemake --cores 8 results/PB2/all/host_stratified/mutation_counts.csv results/PB2/all/host_stratified/parent_child_pairs.csv` — confirm bovine rows (and absence for H1/H3).
2. `snakemake --cores 12 results/subset_aa_fitness_effects.csv` — confirm `subset == 'bovine'`, `subset_type == 'host'` rows.
3. Re-execute the two analyze notebooks — confirm no `Bovine` legend entry, panel, or host in any figure / saved PNG.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
